### PR TITLE
Change node names

### DIFF
--- a/src_mpi/map.cpp
+++ b/src_mpi/map.cpp
@@ -57,7 +57,7 @@ Map Map::fromFile(std::ifstream&& istream, const char delimiter) {
         for(auto i=0; i<verticesCount; ++i) {
             char nodeName[2] = {0};
             //this won't work if verticesCount gets too large; may need another naming convention
-            nodeName[0] = (char) ( (int)('A') + i );
+            nodeName[0] = (char) ( (int) i );
             std::cout << "Adding node: " << nodeName << std::endl;
             m.nodesNames.push_back(std::string(nodeName));
         }

--- a/src_mpi/map.cpp
+++ b/src_mpi/map.cpp
@@ -55,9 +55,9 @@ Map Map::fromFile(std::ifstream&& istream, const char delimiter) {
         }
 
         for(auto i=0; i<verticesCount; ++i) {
-            char nodeName[2] = {0};
+            std::string nodename("");
             //this won't work if verticesCount gets too large; may need another naming convention
-            nodeName[0] = (char) ( (int) i );
+            nodeName += std::string(i);
             std::cout << "Adding node: " << nodeName << std::endl;
             m.nodesNames.push_back(std::string(nodeName));
         }

--- a/src_mpi/map.cpp
+++ b/src_mpi/map.cpp
@@ -60,7 +60,7 @@ Map Map::fromFile(std::ifstream&& istream, const char delimiter) {
             
             //this won't work if verticesCount gets too large; may need another naming convention
             ss << i;
-            std::string nodename = ss.str();
+            std::string nodeName = ss.str();
             std::cout << "Adding node: " << nodeName << std::endl;
             m.nodesNames.push_back(std::string(nodeName));
         }

--- a/src_mpi/map.cpp
+++ b/src_mpi/map.cpp
@@ -61,6 +61,7 @@ Map Map::fromFile(std::ifstream&& istream, const char delimiter) {
             //this won't work if verticesCount gets too large; may need another naming convention
             ss << i;
             std::string nodeName = ss.str();
+            ss.clear();
             std::cout << "Adding node: " << nodeName << std::endl;
             m.nodesNames.push_back(std::string(nodeName));
         }

--- a/src_mpi/map.cpp
+++ b/src_mpi/map.cpp
@@ -53,14 +53,18 @@ Map Map::fromFile(std::ifstream&& istream, const char delimiter) {
                     m.weights[i][j] = std::stoi(numstr);
             }
         }
+        std::stringstream ss;
 
         for(auto i=0; i<verticesCount; ++i) {
-            std::string nodename("");
+            
+            
             //this won't work if verticesCount gets too large; may need another naming convention
-            nodeName += std::string(i);
+            ss << i;
+            std::string nodename = ss.str();
             std::cout << "Adding node: " << nodeName << std::endl;
             m.nodesNames.push_back(std::string(nodeName));
         }
+        
 
         return m;
     }

--- a/src_mpi/map.cpp
+++ b/src_mpi/map.cpp
@@ -61,7 +61,7 @@ Map Map::fromFile(std::ifstream&& istream, const char delimiter) {
             //this won't work if verticesCount gets too large; may need another naming convention
             ss << i;
             std::string nodeName = ss.str();
-            ss.clear();
+            ss.str(std::string());
             std::cout << "Adding node: " << nodeName << std::endl;
             m.nodesNames.push_back(std::string(nodeName));
         }


### PR DESCRIPTION
Changes node names from characters to their numeric index; allows for more nodes, and eliminates cost to find a node's index based on its char name.